### PR TITLE
ecsタスクを起動するsfn用IAMロールを実装

### DIFF
--- a/aws/iam_role.tf
+++ b/aws/iam_role.tf
@@ -57,3 +57,23 @@ resource "aws_iam_role" "iam_for_sfn_execution_s3_check_workflow" {
 }
 EOF
 }
+
+resource "aws_iam_role" "iam_for_sfn_execution_ecs_task" {
+  name = "iam_for_sfn_execution_ecs_task"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "states.amazonaws.com"
+      },
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}

--- a/aws/iam_role_policy_attachment.tf
+++ b/aws/iam_role_policy_attachment.tf
@@ -17,3 +17,8 @@ resource "aws_iam_role_policy_attachment" "sfn_execution_s3_check_workflow" {
   role       = "${aws_iam_role.iam_for_sfn_execution_s3_check_workflow.name}"
   policy_arn = "${aws_iam_policy.lambda_invoke_s3_check_workflow_policy.arn}"
 }
+
+resource "aws_iam_role_policy_attachment" "sfn_execution_ecs_task" {
+  role       = "${aws_iam_role.iam_for_sfn_execution_ecs_task.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonECS_FullAccess"
+}


### PR DESCRIPTION
## ecsタスキを起動するsfn用IAMロールを実装
- `ecs::RunTask`のみでは起動できない。
- AWS公式ポリシーの`arn:aws:iam::aws:policy/AmazonECS_FullAccess`をアタッチして、起動確認

![image](https://user-images.githubusercontent.com/18630053/54740910-1191f580-4c00-11e9-8414-fa80f017698a.png)


![image](https://user-images.githubusercontent.com/18630053/54740976-41d99400-4c00-11e9-8ecd-7f14e6cef936.png)

